### PR TITLE
add prefer-const warning rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,9 @@ module.exports = {
 
     // Our own refactoring rules
     "eyeem-refactor/no-deprecated-imports": 2,
-    "eyeem-refactor/no-classnames-module": 2
+    "eyeem-refactor/no-classnames-module": 2,
+
+    "prefer-const": "warn",
   },
   globals: {
     casper: true,


### PR DESCRIPTION
> If a variable is never reassigned, using the const declaration is better.
const declaration tells readers, “this variable is never reassigned,” reducing cognitive load and improving maintainability.
[...]
This rule is aimed at flagging variables that are declared using let keyword, but never reassigned after the initial assignment.

https://eslint.org/docs/latest/rules/prefer-const

---
As per discussion in F++: 
While this rule to use `const` over `let` seems obvious to someone comfortable with JS style conventions, sometimes someone who comes from a different language gracefully comes in to support us and might forget about this.  